### PR TITLE
Pending deployments

### DIFF
--- a/common/deployment.go
+++ b/common/deployment.go
@@ -9,10 +9,18 @@ import (
 type DeploymentState int
 
 const (
+	// Fresh deployment that has not begun execution.
 	DEPLOYMENT_PENDING DeploymentState = iota
+	// In the process of executing preconditions.
 	RUNNING_PRECONDITIONS
+	// Some preconditions reported pending state and it's waiting for those
+	// preconditions to no longer be pending.
+	PENDING_PRECONDITIONS
+	// Executing its phases.
 	RUNNING_PHASE
+	// All phases completely successfully.
 	DEPLOYMENT_DONE
+	// A phase encountered an error.
 	DEPLOYMENT_ERROR
 )
 
@@ -22,6 +30,8 @@ func (state DeploymentState) String() string {
 		return "DEPLOYMENT_PENDING"
 	case RUNNING_PRECONDITIONS:
 		return "RUNNING_PRECONDITIONS"
+	case PENDING_PRECONDITIONS:
+		return "PENDING_PRECONDITIONS"
 	case RUNNING_PHASE:
 		return "RUNNING_PHASE"
 	case DEPLOYMENT_DONE:

--- a/common/precondition.go
+++ b/common/precondition.go
@@ -3,3 +3,13 @@ package common
 type Precondition interface {
 	Status(Deployment) error
 }
+
+// Wraps an error to signify that it's not a true error but rather pending
+// resolution.
+type PendingError struct {
+	error
+}
+
+func NewPendingError(err error) *PendingError {
+	return &PendingError{err}
+}

--- a/context/pending_deployment.go
+++ b/context/pending_deployment.go
@@ -21,8 +21,8 @@ type PendingDeployment struct {
 func NewPendingDeployment(deployment *Deployment, pending []common.Precondition) *PendingDeployment {
 	return &PendingDeployment{
 		deployment: deployment,
-		pending: pending,
-		passed: []common.Precondition{},
-		failed: []common.Precondition{},
+		pending:    pending,
+		passed:     []common.Precondition{},
+		failed:     []common.Precondition{},
 	}
 }

--- a/context/pending_deployment.go
+++ b/context/pending_deployment.go
@@ -1,0 +1,28 @@
+package context
+
+import (
+	"github.com/Everlane/evan/common"
+)
+
+// Represents a deployment that wasn't able to be immediately deployed but
+// should be deployed after a bit of time once its pending preconditions
+// have been met.
+type PendingDeployment struct {
+	deployment *Deployment
+
+	// List of preconditions which are still reporting a pending status.
+	pending []common.Precondition
+	// Preconditions that ended up failing.
+	passed []common.Precondition
+	// Preconditions that ended up passing.
+	failed []common.Precondition
+}
+
+func NewPendingDeployment(deployment *Deployment, pending []common.Precondition) *PendingDeployment {
+	return &PendingDeployment{
+		deployment: deployment,
+		pending: pending,
+		passed: []common.Precondition{},
+		failed: []common.Precondition{},
+	}
+}

--- a/preconditions/github.go
+++ b/preconditions/github.go
@@ -51,10 +51,14 @@ func (gh *GithubCombinedStatusPrecondition) Status(deployment common.Deployment)
 		return nil
 	}
 
-	if *status.State != "success" {
+	switch *status.State {
+	case "success":
+		return nil
+	case "pending":
+		return common.NewPendingError(fmt.Errorf("Status pending"))
+	default:
 		return fmt.Errorf("Non-success status for ref: %v", *status.State)
 	}
-	return nil
 }
 
 // Require that the branch for deployment not be behind the default branch


### PR DESCRIPTION
Adds the concept of a pending deployment which has a set of pending preconditions. The pending preconditions don't yet know their pass/fail status, so the deployment waits for those pending ones to resolve to an actual pass/fail status before proceeding with the deployment or failing with an error.
